### PR TITLE
audiopolicy: Use legacy alsa to guard incall music feature

### DIFF
--- a/services/audiopolicy/Android.mk
+++ b/services/audiopolicy/Android.mk
@@ -20,7 +20,7 @@ ifeq ($(strip $(AUDIO_FEATURE_ENABLED_HDMI_SPK)),true)
 common_cflags += -DAUDIO_EXTN_HDMI_SPK_ENABLED
 endif
 
-ifneq ($(call is-board-platform-in-list, msm7x30 msm8660 msm8960),true)
+ifneq ($(strip $(BOARD_USES_LEGACY_ALSA_AUDIO)),true)
 ifneq ($(strip $(AUDIO_FEATURE_ENABLED_INCALL_MUSIC)),false)
 common_cflags += -DAUDIO_EXTN_INCALL_MUSIC_ENABLED
 endif


### PR DESCRIPTION
Change-Id: I30f6529fe98e4bfe4afe68b52f9b39a0a7de3cf9