### PR TITLE
nuplayer: Fix incorrect audio resume time during seek

### DIFF
--- a/media/libmediaplayerservice/nuplayer/GenericSource.cpp
+++ b/media/libmediaplayerservice/nuplayer/GenericSource.cpp
@@ -1603,6 +1603,10 @@ void NuPlayer::GenericSource::readBuffer(
             formatChange = false;
             seeking = false;
             ++numBuffers;
+
+            if (trackType == MEDIA_TRACK_TYPE_VIDEO) {
+                actualTimeUs = NULL;
+            }
         } else if (err == WOULD_BLOCK) {
             break;
         } else if (err == INFO_FORMAT_CHANGED) {


### PR DESCRIPTION
GenericSource uses the timestamp of last video buffer
read in readBuffer() to seek audio, due to which audio
starts at a later position leading to frame drops.

Add change to use the first video sample timestamp
to seek audio

Change-Id: I5f2061e67994a3a0330b527bd3164ee04ed04005
CRs-Fixed: 780094