### PR TITLE
stagefright: ffmpeg: Slightly raise the threshold for the ffmpeg scanner

### DIFF
--- a/media/libstagefright/DataSource.cpp
+++ b/media/libstagefright/DataSource.cpp
@@ -179,7 +179,7 @@ bool Sniffer::sniff(
     }
 
     /* Only do the deeper sniffers if the results are null or in doubt */
-    if (mimeType->length() == 0 || *confidence <= 0.2f || forceExtraSniffers) {
+    if (mimeType->length() == 0 || *confidence < 0.21f || forceExtraSniffers) {
         for (List<SnifferFunc>::iterator it = mExtraSniffers.begin();
                 it != mExtraSniffers.end(); ++it) {
             String8 newMimeType;


### PR DESCRIPTION
0.2 is the success value for the OMX.google soft audio sniffers, which
was making ffmpeg own the unpacking of those streams needlessly.

Fixes CYNGNOS-282

Change-Id: I75f50ed838cb8af9acdf99aa284b80a070555284